### PR TITLE
Fix unformat for certain currencies & minus sign.

### DIFF
--- a/addon/unformat.js
+++ b/addon/unformat.js
@@ -43,10 +43,13 @@ function unformat(value, decimal) {
 
    // Build regex to strip out everything except digits, decimal point and minus sign:
   var regex = new RegExp("[^0-9-" + decimal + "]", ["g"]);
+  var decimalClean = new RegExp('^\\' + decimal);
   var unformatted = parseFloat(
     ("" + value)
+    .replace(/\u2212/g, '-')    // replace &minus; with '-'
     .replace(/\((.*)\)/, "-$1") // replace bracketed values with negatives
     .replace(regex, '')         // strip out any cruft
+    .replace(decimalClean, '')  // strip out leading decimals
     .replace(decimal, '.')      // make sure decimal point is standard
   );
 

--- a/tests/unit/unformat-test.js
+++ b/tests/unit/unformat-test.js
@@ -10,6 +10,10 @@ test("unformat()", function(assert) {
 	assert.equal(unformat("string"), 0, 'Returns 0 for a string with no numbers');
 	assert.equal(unformat({joss:1}), 0, 'Returns 0 for object');
 
+	assert.equal(unformat('Bs.123.56'), 123.56, 'Can unformat Bs.');
+	assert.equal(unformat('Rs. 123.56'), 123.56, 'Can unformat Rs.');
+	assert.equal(unformat('\u2212123.56'), -123.56, 'Can unformat minus sign');
+
 	number.decimal = ',';
 	assert.equal(unformat("100,00"), 100, 'Uses decimal separator from settings');
 	assert.equal(unformat("¤1.000,00"), 1000, 'Uses decimal separator from settings');


### PR DESCRIPTION
If you enter a unicode minus sign (which can happen due to internalization), it gets stripped out when un-formatting. We should treat it as an actual minus sign. 